### PR TITLE
Added a very basic function to use custom data path. 

### DIFF
--- a/lua/triforce/init.lua
+++ b/lua/triforce/init.lua
@@ -48,6 +48,7 @@ end
 ---@field custom_languages? table<string, TriforceLanguage>|nil Custom language definitions { filetype = { icon = "", name = "" } }
 ---@field level_progression? LevelProgression|nil Custom level progression tiers
 ---@field xp_rewards? XPRewards|nil Custom XP reward amounts for different actions
+---@field db_path? string
 local defaults = {
   enabled = true,
   gamification_enabled = true,
@@ -67,6 +68,7 @@ local defaults = {
     line = 1, -- XP per new line (changed from 10 to 1)
     save = 50, -- XP per file save
   },
+  db_path = vim.fn.stdpath('data') .. '/triforce_stats.json', -- custom path for data file
 }
 
 ---@type TriforceConfig
@@ -87,16 +89,17 @@ function M.setup(opts)
     require('triforce.languages').register_custom_languages(M.config.custom_languages)
   end
 
+  -- Setup custom path if provided
+  if M.config.db_path then
+    require('triforce.stats').db_path = M.config.db_path
+  end
+
   -- Set up keymap if provided
   if M.config.keymap and M.config.keymap.show_profile then
     vim.keymap.set('n', M.config.keymap.show_profile, M.show_profile, {
       desc = 'Show Triforce Profile',
       silent = true,
-      noremap = true,
-    })
-  end
-
-  if M.config.enabled and M.config.gamification_enabled then
+      noremap  M.config.enabled and M.config.gamification_enabled then
     require('triforce.tracker').setup()
   end
 end

--- a/lua/triforce/stats.lua
+++ b/lua/triforce/stats.lua
@@ -24,6 +24,7 @@ M.level_config = {
 ---@field daily_activity table<string, integer> Lines typed per day (YYYY-MM-DD format)
 ---@field current_streak integer Current consecutive day streak
 ---@field longest_streak integer Longest ever streak
+---@field db_path string
 M.default_stats = {
   xp = 0,
   level = 1,
@@ -37,11 +38,16 @@ M.default_stats = {
   daily_activity = {},
   current_streak = 0,
   longest_streak = 0,
+  db_path = nil,
 }
 
 ---Get the stats file path
 local function get_stats_path()
-  return vim.fn.stdpath('data') .. '/triforce_stats.json'
+  if M.default_stats.db_path == nil then
+    return vim.fn.stdpath('data') .. '/triforce_stats.json'
+  else
+    return M.default_stats.db_path
+  end
 end
 
 ---Prepare stats for JSON encoding (handle empty tables)


### PR DESCRIPTION
Only tested on Linux. Uses a string. AFAIK only works with absolute paths.

Nothing crazy. I just saw there wasn't an option to set a custom path. I sync my neovim configuration using syncthing and I wanted a custom path for my data. Maybe there is a better implementation. This should enable git too, if they just put the custom path somewhere in their dotfiles repository.

The extra 3 lines should be self explanatory, but just email me for questions, if you have any. Thanks for making the plugin in the first place, very cool.

I might work on infinite tiers and special name descriptors for tiers next, e.g instead of tier1 "mercenary" or "hero" and then as you go higher I might rename them "demigod" etc. But idk. 