### PR TITLE
fix(tracker)!: only grant XP if file is modified (fixes #12)

### DIFF
--- a/lua/triforce/tracker.lua
+++ b/lua/triforce/tracker.lua
@@ -47,10 +47,12 @@ function M.setup()
       M.on_text_changed()
     end,
   })
-  vim.api.nvim_create_autocmd('BufWritePost', {
+  vim.api.nvim_create_autocmd('BufWritePre', {
     group = M.autocmd_group,
-    callback = function()
-      M.on_save()
+    callback = function(ev)
+      if vim.api.nvim_get_option_value('modified', { buf = ev.buf }) then
+        M.on_save()
+      end
     end,
   })
   vim.api.nvim_create_autocmd('VimLeavePre', {


### PR DESCRIPTION
## Description

I modified the `BufWritePost` autocmd to only execute `on_save()` if buffer has been modified.

Should fix #12. I have done some testing for this and it works indeed.

Need a second opinion on this.
