### PR TITLE
refactor(health): split health checks into different sections

### DIFF
--- a/lua/triforce/health.lua
+++ b/lua/triforce/health.lua
@@ -5,7 +5,7 @@
 local M = {}
 
 function M.check()
-  vim.health.start('triforce.nvim')
+  vim.health.start('Version Check')
   local nvim_version = vim.version()
   if nvim_version.major == 0 and nvim_version.minor >= 9 then
     vim.health.ok(('Neovim version: %s.%s.%s'):format(nvim_version.major, nvim_version.minor, nvim_version.patch))
@@ -13,6 +13,7 @@ function M.check()
     vim.health.error('Neovim >= 0.9.0 is required')
   end
 
+  vim.health.start('triforce.nvim')
   local ok, triforce = pcall(require, 'triforce')
   if not ok then
     vim.health.error('Failed to load triforce module: ' .. vim.inspect(triforce))
@@ -25,14 +26,17 @@ function M.check()
     vim.health.warn('Plugin is disabled in configuration')
   end
 
+  vim.health.start('Gamification')
   if not triforce.config.gamification_enabled then
     vim.health.warn('Gamification is disabled')
     return
   end
   vim.health.ok('Gamification is enabled')
+
+  vim.health.start('Stats File')
   local stats_path = vim.fs.joinpath(vim.fn.stdpath('data'), 'triforce_stats.json')
   if vim.fn.filereadable(stats_path) == 1 then
-    vim.health.ok('Stats file found: ' .. stats_path)
+    vim.health.ok(('Stats file found: `%s`'):format(stats_path))
     return
   end
   vim.health.info('Stats file not yet created (will be created on first use)')


### PR DESCRIPTION
## Description

Took the liberty to split certain health checks into sections for better extensibility and transparency.

Thoughts? Let me know of any feedback.

## Example

I'm using my Neovim config[^1] in these screenshots. [Here's the triforce config](https://github.com/DrKJeff16/nvim/blob/main/lua/plugin/triforce.lua).

### Before

<img width="1264" height="270" alt="BEFORE" src="https://github.com/user-attachments/assets/f95d4047-4f30-45a1-9632-2a5b266aaeb6" />

### After

<img width="1286" height="474" alt="AFTER" src="https://github.com/user-attachments/assets/01ba31a3-cae7-4a15-929a-acc67fa0385f" />

[^1]: https://github.com/DrKJeff16/nvim
